### PR TITLE
add-validation-responses

### DIFF
--- a/ramls/idm-connect.raml
+++ b/ramls/idm-connect.raml
@@ -6,11 +6,13 @@ version: v1.0
 types:
   contract: !include contract.json
   contracts: !include contracts.json
+  errors: !include raml-util/schemas/errors.schema
 
 traits:
   language: !include raml-util/traits/language.raml
   pageable: !include raml-util/traits/pageable.raml
   searchable: !include raml-util/traits/searchable.raml
+  validate: !include raml-util/traits/validation.raml
 
 resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
@@ -23,6 +25,8 @@ resourceTypes:
         searchable: {description: "", example: ""},
         pageable
       ]
+    post:
+      is: [validate]
     type:
       collection:
         schemaCollection: contracts
@@ -30,6 +34,8 @@ resourceTypes:
         exampleCollection: !include examples/contracts.json
         exampleItem: !include examples/contract.json
     /{id}:
+      put:
+        is: [validate]
       type:
         collection-item:
           schema: contract

--- a/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
+++ b/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
@@ -13,7 +13,6 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.JacksonCodec;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.WebClient;
@@ -89,11 +88,9 @@ public class CustomTenantApiIT {
 
   @Test
   public void testWithoutLoadSampleAttribute(TestContext context) {
-    Async async = context.async();
     tenantUtil
         .setupTenant(new TenantAttributes().withModuleTo(ModuleName.getModuleVersion()))
-        .onComplete(context.asyncAssertSuccess(h -> async.complete()));
-    async.awaitSuccess();
+        .onComplete(context.asyncAssertSuccess());
 
     Contracts getResult = given().get().then().extract().as(Contracts.class);
     assertThat(getResult)
@@ -106,14 +103,12 @@ public class CustomTenantApiIT {
 
   @Test
   public void testWithLoadSampleAttribute(TestContext context) {
-    Async async = context.async();
     tenantUtil
         .setupTenant(
             new TenantAttributes()
                 .withModuleTo(ModuleName.getModuleVersion())
                 .withParameters(List.of(new Parameter().withKey("loadSample").withValue("true"))))
-        .onComplete(context.asyncAssertSuccess(h -> async.complete()));
-    async.awaitSuccess();
+        .onComplete(context.asyncAssertSuccess());
 
     Contracts getResult = given().get().then().extract().as(Contracts.class);
     assertThat(getResult)

--- a/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
+++ b/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
@@ -31,6 +31,7 @@ import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.ModuleName;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.tools.utils.VertxUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -43,7 +44,7 @@ public class CustomTenantApiIT {
   private static final String HOST = "http://localhost";
   private static final String TENANT = "diku";
   private static final Map<String, String> OKAPI_HEADERS = Map.of("x-okapi-tenant", TENANT);
-  private static final Vertx vertx = Vertx.vertx();
+  private static final Vertx vertx = VertxUtils.getVertxFromContextOrNew();
   private static List<Contract> exampleContracts;
   private static TenantUtil tenantUtil;
 

--- a/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
@@ -30,6 +30,7 @@ import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.ModuleName;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.tools.utils.VertxUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class IdmConnectContractApiIT {
   private static final String TENANT = "diku";
   private static final Map<String, String> OKAPI_HEADERS = Map.of("x-okapi-tenant", TENANT);
   private static final String CONTRACT_JSON = "examplecontract.json";
-  private static final Vertx vertx = Vertx.vertx();
+  private static final Vertx vertx = VertxUtils.getVertxFromContextOrNew();
   private static TenantUtil tenantUtil;
 
   @BeforeClass

--- a/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
@@ -13,7 +13,6 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.WebClient;
@@ -86,18 +85,14 @@ public class IdmConnectContractApiIT {
 
   @Before
   public void setUp(TestContext context) {
-    Async async = context.async();
     tenantUtil
         .setupTenant(new TenantAttributes().withModuleTo(ModuleName.getModuleVersion()))
-        .onComplete(context.asyncAssertSuccess(h -> async.complete()));
-    async.awaitSuccess();
+        .onComplete(context.asyncAssertSuccess());
   }
 
   @After
   public void tearDown(TestContext context) {
-    Async async = context.async();
-    tenantUtil.teardownTenant().onComplete(context.asyncAssertSuccess(h -> async.complete()));
-    async.awaitSuccess();
+    tenantUtil.teardownTenant().onComplete(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/IdmConnectSearchidmApiIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectSearchidmApiIT.java
@@ -23,6 +23,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.util.Map;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.tools.utils.VertxUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -43,7 +44,7 @@ public class IdmConnectSearchidmApiIT {
   private static final String HOST = "http://localhost";
   private static final String TENANT = "diku";
   private static final Map<String, String> OKAPI_HEADERS = Map.of("x-okapi-tenant", TENANT);
-  private static final Vertx vertx = Vertx.vertx();
+  private static final Vertx vertx = VertxUtils.getVertxFromContextOrNew();
   private static final String IDM_TOKEN = "someToken";
   private static String IDM_MOCK_URL;
 


### PR DESCRIPTION
This PR adds validation responses (422) to the raml file for `POST`and `PUT` requests on `/idm-connect/contract` path.
Also test cases are added for these responses.