### PR TITLE
Add spotless-maven-plugin and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contribution guidelines
+
+## Guidelines for Contributing Code:
+
+[dev.folio.org/guidelines/contributing](https://dev.folio.org/guidelines/contributing)
+
+## Code Formatting
+
+This project follows the [Google Java Style](https://google.github.io/styleguide/javaguide.html)
+for code formatting. To ensure consistency in the codebase, please format your code according to
+these guidelines before submitting a pull request.
+
+Use `mvn spotless:check` to check for formatting violations and `mvn spotless:apply` to
+automatically fix them.

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
     <log4j-bom.version>2.24.3</log4j-bom.version>
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
+    <spotless.version>3.1.0</spotless.version>
+    <google-java-format.version>1.33.0</google-java-format.version>
   </properties>
 
   <dependencyManagement>
@@ -87,6 +89,22 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <ratchetFrom>origin/master</ratchetFrom>
+          <java>
+            <googleJavaFormat>
+              <version>${google-java-format.version}</version>
+              <style>GOOGLE</style>
+              <reflowLongStrings>true</reflowLongStrings>
+              <formatJavadoc>true</formatJavadoc>
+            </googleJavaFormat>
+          </java>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.folio</groupId>
         <artifactId>folio-module-descriptor-validator</artifactId>


### PR DESCRIPTION
## Purpose

Introduce automated code formatting to ensure consistent code style across the project. This makes code reviews easier by eliminating style debates and helps maintain a clean, readable codebase.

## Approach

- Add `spotless-maven-plugin` configured with Google Java Style
- Use `ratchetFrom: origin/master` for incremental adoption (only checks changed files)
- Add `CONTRIBUTING.md` documenting the formatting requirements and commands
