### PR TITLE
[MODIDM-27] Upgrade module to Vert.x 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
-    <rmb.version>35.4.0</rmb.version>
-    <vertx.version>4.5.13</vertx.version>
+    <rmb.version>36.0.0-SNAPSHOT</rmb.version>
+    <vertx.version>5.0.6</vertx.version>
     <aspect.version>1.9.22.1</aspect.version>
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
     <log4j-bom.version>2.24.3</log4j-bom.version>
@@ -188,7 +188,7 @@
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <complianceLevel>17</complianceLevel>
+          <complianceLevel>${maven.compiler.release}</complianceLevel>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <aspectLibraries>
             <aspectLibrary>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
     <spotless.version>3.1.0</spotless.version>
     <google-java-format.version>1.33.0</google-java-format.version>
+    <junit.version>5.11.4</junit.version>
   </properties>
 
   <dependencyManagement>
@@ -39,6 +40,13 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -83,6 +91,16 @@
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <version>3.12.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/folio/rest/impl/CustomTenantApi.java
+++ b/src/main/java/org/folio/rest/impl/CustomTenantApi.java
@@ -2,11 +2,10 @@ package org.folio.rest.impl;
 
 import static org.folio.idmconnect.Constants.TABLE_NAME_CONTRACTS;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.io.Resources;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.json.jackson.JacksonCodec;
+import io.vertx.core.json.Json;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -34,7 +33,7 @@ public class CustomTenantApi extends TenantAPI {
                   String contractsStr =
                       Resources.toString(
                           Resources.getResource("examplecontracts.json"), StandardCharsets.UTF_8);
-                  contracts = JacksonCodec.decodeValue(contractsStr, new TypeReference<>() {});
+                  contracts = List.of(Json.decodeValue(contractsStr, Contract[].class));
                   MetadataUtil.populateMetadata(contracts, headers);
                 } catch (IOException | ReflectiveOperationException e) {
                   return Future.failedFuture(e);

--- a/src/main/java/org/folio/rest/impl/IdmConnectApi.java
+++ b/src/main/java/org/folio/rest/impl/IdmConnectApi.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import javax.ws.rs.core.Response;
 import org.folio.idmconnect.IdmClient;
 import org.folio.idmconnect.IdmClientFactory;
-import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.jaxrs.model.BulkDeleteRequest;
 import org.folio.rest.jaxrs.model.BulkDeleteResponse;
 import org.folio.rest.jaxrs.model.Contract;
@@ -170,7 +169,7 @@ public class IdmConnectApi implements IdmConnect {
                             }))
             .collect(Collectors.toList());
 
-    CompositeFuture join = GenericCompositeFuture.join(results);
+    CompositeFuture join = Future.join(results);
     join.onComplete(
         ar -> {
           List<String> failedUUIDs =

--- a/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
+++ b/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
@@ -5,24 +5,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.utils.TestConstants.HOST;
 import static org.folio.utils.TestConstants.IDM_TOKEN;
 import static org.folio.utils.TestConstants.TENANT;
+import static org.folio.utils.TestConstants.deployRestVerticle;
 import static org.folio.utils.TestConstants.setupRestAssured;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.io.Resources;
 import io.restassured.RestAssured;
-import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.jackson.JacksonCodec;
+import io.vertx.core.json.Json;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.WebClient;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import org.folio.postgres.testing.PostgresTesterContainer;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Contract;
 import org.folio.rest.jaxrs.model.Contracts;
@@ -53,7 +51,7 @@ public class CustomTenantApiIT {
 
     String exampleContractsStr =
         Resources.toString(Resources.getResource("examplecontracts.json"), StandardCharsets.UTF_8);
-    exampleContracts = JacksonCodec.decodeValue(exampleContractsStr, new TypeReference<>() {});
+    exampleContracts = Arrays.asList(Json.decodeValue(exampleContractsStr, Contract[].class));
 
     tenantUtil =
         new TenantUtil(
@@ -61,10 +59,7 @@ public class CustomTenantApiIT {
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
     PostgresClient.getInstance(vertx);
 
-    DeploymentOptions options =
-        new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
-
-    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess());
+    deployRestVerticle(vertx, port).onComplete(context.asyncAssertSuccess());
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
+++ b/src/test/java/org/folio/rest/impl/CustomTenantApiIT.java
@@ -24,10 +24,7 @@ import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Contract;
 import org.folio.rest.jaxrs.model.Contracts;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.utils.ModuleName;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.tools.utils.VertxUtils;
 import org.folio.utils.TenantUtil;
@@ -75,7 +72,7 @@ public class CustomTenantApiIT {
   @Test
   public void testWithoutLoadSampleAttribute(TestContext context) {
     tenantUtil
-        .setupTenant(new TenantAttributes().withModuleTo(ModuleName.getModuleVersion()))
+        .setupTenant(false)
         .map(
             v -> {
               Contracts getResult = given().get().then().extract().as(Contracts.class);
@@ -93,10 +90,7 @@ public class CustomTenantApiIT {
   @Test
   public void testWithLoadSampleAttribute(TestContext context) {
     tenantUtil
-        .setupTenant(
-            new TenantAttributes()
-                .withModuleTo(ModuleName.getModuleVersion())
-                .withParameters(List.of(new Parameter().withKey("loadSample").withValue("true"))))
+        .setupTenant(true)
         .map(
             v -> {
               Contracts getResult = given().get().then().extract().as(Contracts.class);

--- a/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
@@ -36,9 +36,7 @@ import org.folio.rest.jaxrs.model.Contract;
 import org.folio.rest.jaxrs.model.Contract.Status;
 import org.folio.rest.jaxrs.model.Contracts;
 import org.folio.rest.jaxrs.model.Personal;
-import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.utils.ModuleName;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.tools.utils.VertxUtils;
 import org.folio.utils.TenantUtil;
@@ -85,9 +83,7 @@ public class IdmConnectContractApiIT {
 
   @Before
   public void setUp(TestContext context) {
-    tenantUtil
-        .setupTenant(new TenantAttributes().withModuleTo(ModuleName.getModuleVersion()))
-        .onComplete(context.asyncAssertSuccess());
+    tenantUtil.setupTenant(false).onComplete(context.asyncAssertSuccess());
   }
 
   @After

--- a/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectContractApiIT.java
@@ -9,6 +9,7 @@ import static org.folio.utils.TestConstants.HOST;
 import static org.folio.utils.TestConstants.IDM_TOKEN;
 import static org.folio.utils.TestConstants.PATH_ID;
 import static org.folio.utils.TestConstants.TENANT;
+import static org.folio.utils.TestConstants.deployRestVerticle;
 import static org.folio.utils.TestConstants.setupRestAssured;
 import static org.folio.utils.TestEntities.DRAFT;
 import static org.folio.utils.TestEntities.PENDING;
@@ -18,10 +19,8 @@ import static org.folio.utils.TestEntities.UPDATED;
 
 import com.google.common.io.Resources;
 import io.restassured.RestAssured;
-import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.WebClient;
@@ -30,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 import org.folio.postgres.testing.PostgresTesterContainer;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.BulkDeleteRequest;
 import org.folio.rest.jaxrs.model.BulkDeleteResponse;
@@ -77,10 +75,7 @@ public class IdmConnectContractApiIT {
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
     PostgresClient.getInstance(vertx);
 
-    DeploymentOptions options =
-        new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
-
-    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess());
+    deployRestVerticle(vertx, port).onComplete(context.asyncAssertSuccess());
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/impl/IdmConnectContractApiTransmitIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectContractApiTransmitIT.java
@@ -16,6 +16,7 @@ import static org.folio.utils.TestConstants.IDM_TOKEN;
 import static org.folio.utils.TestConstants.PATH_ID;
 import static org.folio.utils.TestConstants.PATH_TRANSMIT;
 import static org.folio.utils.TestConstants.TENANT;
+import static org.folio.utils.TestConstants.deployRestVerticle;
 import static org.folio.utils.TestConstants.setupRestAssured;
 import static org.folio.utils.TestEntities.DRAFT;
 import static org.folio.utils.TestEntities.PENDING;
@@ -30,16 +31,13 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import io.restassured.RestAssured;
-import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.WebClient;
 import org.folio.idmconnect.IdmClientConfig;
 import org.folio.idmconnect.IdmClientFactory;
 import org.folio.postgres.testing.PostgresTesterContainer;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Contract;
 import org.folio.rest.persist.PostgresClient;
@@ -75,10 +73,7 @@ public class IdmConnectContractApiTransmitIT {
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
     PostgresClient.getInstance(vertx);
 
-    DeploymentOptions options =
-        new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
-
-    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess());
+    deployRestVerticle(vertx, port).onComplete(context.asyncAssertSuccess());
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/impl/IdmConnectSearchidmApiIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectSearchidmApiIT.java
@@ -13,21 +13,19 @@ import static org.folio.idmconnect.Constants.MSG_IDM_URL_NOT_SET;
 import static org.folio.utils.TestConstants.CONNECTION_REFUSED;
 import static org.folio.utils.TestConstants.HOST;
 import static org.folio.utils.TestConstants.IDM_TOKEN;
+import static org.folio.utils.TestConstants.deployRestVerticle;
 import static org.folio.utils.TestConstants.setupRestAssured;
 import static org.hamcrest.Matchers.containsString;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.RestAssured;
-import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.util.Map;
 import org.folio.idmconnect.IdmClientConfig;
 import org.folio.idmconnect.IdmClientFactory;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.tools.utils.VertxUtils;
 import org.junit.AfterClass;
@@ -51,9 +49,7 @@ public class IdmConnectSearchidmApiIT {
     int port = NetworkUtils.nextFreePort();
     setupRestAssured(port, BASE_PATH_SEARCHIDM);
 
-    DeploymentOptions options =
-        new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
-    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess());
+    deployRestVerticle(vertx, port).onComplete(context.asyncAssertSuccess());
 
     IDM_MOCK_URL = idmApiMock.baseUrl() + BASE_PATH_SEARCHIDM;
     idmApiMock.stubFor(

--- a/src/test/java/org/folio/rest/impl/IdmConnectUBReaderNumberApiIT.java
+++ b/src/test/java/org/folio/rest/impl/IdmConnectUBReaderNumberApiIT.java
@@ -22,6 +22,7 @@ import static org.folio.utils.TestConstants.IDM_TOKEN;
 import static org.folio.utils.TestConstants.OKAPI_HEADERS;
 import static org.folio.utils.TestConstants.PATH_ID;
 import static org.folio.utils.TestConstants.TENANT;
+import static org.folio.utils.TestConstants.deployRestVerticle;
 import static org.folio.utils.TestConstants.setupRestAssured;
 import static org.hamcrest.Matchers.containsString;
 
@@ -30,9 +31,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.RestAssured;
-import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.WebClient;
@@ -40,7 +39,6 @@ import java.util.Map;
 import org.folio.idmconnect.IdmClientConfig;
 import org.folio.idmconnect.IdmClientFactory;
 import org.folio.postgres.testing.PostgresTesterContainer;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Contract;
 import org.folio.rest.persist.PostgresClient;
@@ -93,9 +91,7 @@ public class IdmConnectUBReaderNumberApiIT {
         new TenantUtil(
             new TenantClient(HOST + ":" + port, TENANT, IDM_TOKEN, WebClient.create(vertx)));
 
-    DeploymentOptions options =
-        new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
-    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess());
+    deployRestVerticle(vertx, port).onComplete(context.asyncAssertSuccess());
 
     idmApiMock.stubFor(
         any(urlPathEqualTo(MOCK_BASE_PATH))

--- a/src/test/java/org/folio/utils/TenantUtil.java
+++ b/src/test/java/org/folio/utils/TenantUtil.java
@@ -68,7 +68,9 @@ public class TenantUtil {
 
   public Future<Void> setupTenant(boolean loadSample) {
     return setupTenant(
-        new TenantAttributes().withModuleTo(ModuleName.getModuleVersion()), loadSample);
+        new TenantAttributes()
+            .withModuleTo(ModuleName.getModuleName() + "-" + ModuleName.getModuleVersion()),
+        loadSample);
   }
 
   public Future<Void> setupTenant(TenantAttributes tenantAttributes) {

--- a/src/test/java/org/folio/utils/TestConstants.java
+++ b/src/test/java/org/folio/utils/TestConstants.java
@@ -7,7 +7,12 @@ import static org.folio.idmconnect.Constants.BASE_PATH_CONTRACTS;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.parsing.Parser;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import java.util.Map;
+import org.folio.rest.RestVerticle;
 
 public class TestConstants {
 
@@ -34,6 +39,12 @@ public class TestConstants {
             .addHeaders(OKAPI_HEADERS)
             .addHeader(CONTENT_TYPE, APPLICATION_JSON)
             .build();
+  }
+
+  public static Future<String> deployRestVerticle(Vertx vertx, int port) {
+    DeploymentOptions options =
+        new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
+    return vertx.deployVerticle(RestVerticle.class.getName(), options);
   }
 
   private TestConstants() {}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODIDM-27

## Purpose

Upgrade to Vert.x 5 and RMB 36.

## Approach

- Upgrade Vert.x from 4.5.13 to 5.0.6
- Upgrade RMB from 35.4.0 to 36.0.0-SNAPSHOT
- Add JUnit 5 BOM with vintage engine for JUnit 4 test compatibility
- Adapt code for Vert.x 5 API changes:
  - Replace `JacksonCodec.decodeValue()` with `Json.decodeValue()`
  - Replace `GenericCompositeFuture.join()` with `Future.join()`
  - Update `deployVerticle()` calls to use Future-based API
- Refactor test setup into shared `deployRestVerticle()` utility
- Fix `module_to` tenant parameter format
