### PR TITLE
[MODIDM-28] Add HTTP proxy support to IdmClientImpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-idm-connect
 
-Copyright (C) 2021-2023 The Open Library Foundation
+Copyright (C) 2021-2026 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0. See the
 file "[LICENSE](LICENSE)" for more information.
@@ -24,3 +24,45 @@ environment variables:
 | `IDM_CONTRACT_URL`      | Contracts endpoint                              |               |
 | `IDM_READER_NUMBER_URL` | Card number endpoint                            |               |
 | `IDM_TRUST_ALL`         | Whether all servers (SSL/TLS) should be trusted | false         |
+
+### Proxy Configuration
+
+HTTP/HTTPS proxy configuration is supported for connections to the external IDM system.
+
+#### Java System Properties
+
+Proxy settings are configured via JVM system properties:
+
+```bash
+-Dhttp.proxyHost=proxy.example.com
+-Dhttp.proxyPort=8080
+-Dhttps.proxyHost=proxy.example.com
+-Dhttps.proxyPort=8443
+-Dhttp.nonProxyHosts=localhost|127.0.0.1|*.internal
+```
+
+#### Docker Environment Variables
+
+When running in a Docker container, you can use standard environment variables which are translated
+into system properties by the base image:
+
+| Variable      | Description                                   | Example                          |
+|---------------|-----------------------------------------------|----------------------------------|
+| `HTTP_PROXY`  | HTTP proxy URL                                | `http://proxy.example.com:8080`  |
+| `HTTPS_PROXY` | HTTPS proxy URL                               | `https://proxy.example.com:8443` |
+| `NO_PROXY`    | Comma-separated list of hosts to bypass proxy | `localhost,127.0.0.1,.internal`  |
+
+#### Docker Compose Example
+
+```yaml
+version: '3'
+services:
+  mod-idm-connect:
+    image: mod-idm-connect:latest
+    environment:
+      - HTTP_PROXY=http://proxy.example.com:8080
+      - HTTPS_PROXY=https://proxy.example.com:8443
+      - NO_PROXY=localhost,127.0.0.1
+      - IDM_URL=http://idm.example.com/api
+      - IDM_TOKEN=your-token-here
+```

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/folio/idmconnect/IdmClientImplIT.java
+++ b/src/test/java/org/folio/idmconnect/IdmClientImplIT.java
@@ -1,0 +1,115 @@
+package org.folio.idmconnect;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.net.Proxy.Type.HTTP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.utils.TestConstants.createProxySelector;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.junit5.VertxExtension;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@ExtendWith(VertxExtension.class)
+@DisplayName("IdmClientImpl Integration Tests")
+class IdmClientImplIT {
+
+  private static final String TEST_GIVEN_NAME = "John";
+  private static final String TEST_SURNAME = "Doe";
+  private static final String TEST_DATE_OF_BIRTH = "1990-01-15";
+  private static final String TEST_DATE_OF_BIRTH_FORMATTED = "19900115";
+
+  @RegisterExtension
+  static WireMockExtension targetServer =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  @RegisterExtension
+  static WireMockExtension proxyServer =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private static final ProxySelector originalProxySelector = ProxySelector.getDefault();
+  private static WebClient webClient;
+  private static IdmClient idmClient;
+
+  @BeforeAll
+  static void beforeAll(Vertx vertx) {
+    webClient = WebClient.create(vertx, new WebClientOptions());
+    IdmClientConfig config =
+        new IdmClientConfig.Builder()
+            .idmUrl("http://localhost:" + targetServer.getPort() + "/search")
+            .idmToken("test-token")
+            .build();
+    idmClient = new IdmClientImpl(config, webClient);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    ProxySelector.setDefault(originalProxySelector);
+    if (webClient != null) {
+      webClient.close();
+    }
+  }
+
+  @BeforeEach
+  void setup() {
+    targetServer.stubFor(get(urlPathEqualTo("/search")).willReturn(aResponse().withStatus(200)));
+    proxyServer.stubFor(
+        get(urlMatching(".*"))
+            .willReturn(aResponse().proxiedFrom("http://localhost:" + targetServer.getPort())));
+  }
+
+  @Test
+  @DisplayName("Should route requests through proxy when configured")
+  void proxyIsUsedWhenConfigured() throws Exception {
+    Proxy proxy = new Proxy(HTTP, new InetSocketAddress("localhost", proxyServer.getPort()));
+    ProxySelector.setDefault(createProxySelector(proxy));
+
+    Response response = makeSearchRequest();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    verifySearchRequest(proxyServer);
+    verifySearchRequest(targetServer);
+  }
+
+  @Test
+  @DisplayName("Should connect directly when no proxy is configured")
+  void noProxyIsUsedWhenNotConfigured() throws Exception {
+    ProxySelector.setDefault(createProxySelector(Proxy.NO_PROXY));
+
+    Response response = makeSearchRequest();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    verifySearchRequest(targetServer);
+    assertThat(proxyServer.getAllServeEvents()).isEmpty();
+  }
+
+  private Response makeSearchRequest() throws Exception {
+    return idmClient
+        .search(TEST_GIVEN_NAME, TEST_SURNAME, TEST_DATE_OF_BIRTH)
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get();
+  }
+
+  private void verifySearchRequest(WireMockExtension server) {
+    server.verify(
+        getRequestedFor(urlPathEqualTo("/search"))
+            .withQueryParam("givenname", equalTo(TEST_GIVEN_NAME))
+            .withQueryParam("surname", equalTo(TEST_SURNAME))
+            .withQueryParam("date_of_birth", equalTo(TEST_DATE_OF_BIRTH_FORMATTED)));
+  }
+}

--- a/src/test/java/org/folio/idmconnect/IdmClientImplTest.java
+++ b/src/test/java/org/folio/idmconnect/IdmClientImplTest.java
@@ -1,0 +1,75 @@
+package org.folio.idmconnect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.utils.TestConstants.createProxySelector;
+
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("IdmClientImpl Unit Tests")
+class IdmClientImplTest {
+
+  private static final ProxySelector originalProxySelector = ProxySelector.getDefault();
+  private static final String TARGET_URL = "http://localhost:8080";
+
+  @AfterAll
+  static void restoreProxySelector() {
+    ProxySelector.setDefault(originalProxySelector);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"ht!tp://invalid url with spaces"})
+  @DisplayName("Should return empty Optional for invalid URLs")
+  void testGetProxyOptionsReturnsEmptyForInvalidUrls(String url) {
+    Optional<ProxyOptions> result = IdmClientImpl.getProxyOptions(url);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should return empty Optional when no proxy is configured")
+  void testGetProxyOptionsWithNoProxy() {
+    ProxySelector.setDefault(createProxySelector(Proxy.NO_PROXY));
+
+    Optional<ProxyOptions> result = IdmClientImpl.getProxyOptions(TARGET_URL);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should return ProxyOptions when HTTP proxy is configured")
+  void testGetProxyOptionsWithHttpProxy() {
+    Proxy httpProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxy.example.com", 8080));
+    ProxySelector.setDefault(createProxySelector(httpProxy));
+
+    Optional<ProxyOptions> result = IdmClientImpl.getProxyOptions(TARGET_URL);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getHost()).isEqualTo("proxy.example.com");
+    assertThat(result.get().getPort()).isEqualTo(8080);
+    assertThat(result.get().getType()).isEqualTo(ProxyType.HTTP);
+  }
+
+  @Test
+  @DisplayName("Should return empty Optional when SOCKS proxy is configured")
+  void testGetProxyOptionsWithSocksProxy() {
+    Proxy socksProxy =
+        new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("socks.example.com", 1080));
+    ProxySelector.setDefault(createProxySelector(socksProxy));
+
+    Optional<ProxyOptions> result = IdmClientImpl.getProxyOptions(TARGET_URL);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/java/org/folio/utils/TestConstants.java
+++ b/src/test/java/org/folio/utils/TestConstants.java
@@ -11,6 +11,12 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import org.folio.rest.RestVerticle;
 
@@ -45,6 +51,20 @@ public class TestConstants {
     DeploymentOptions options =
         new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
     return vertx.deployVerticle(RestVerticle.class.getName(), options);
+  }
+
+  public static ProxySelector createProxySelector(Proxy proxy) {
+    return new ProxySelector() {
+      @Override
+      public List<Proxy> select(URI uri) {
+        return List.of(proxy);
+      }
+
+      @Override
+      public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+        // No-op for test
+      }
+    };
   }
 
   private TestConstants() {}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODIDM-28

## Purpose

This change enables `mod-idm-connect` to use proxy servers when connecting to the external IDM system, allowing the module to operate in environments with restricted network access or where network policies mandate proxy usage.

## Approach

Implemented `getProxyOptions()` method in `IdmClientImpl` that uses `ProxySelector.getDefault()` to resolve proxy configuration for target URLs, applying the resolved proxy settings to HTTP requests.
